### PR TITLE
Send language tags for language switches

### DIFF
--- a/addon/synthDrivers/tiflotecniaVoices/__init__.py
+++ b/addon/synthDrivers/tiflotecniaVoices/__init__.py
@@ -86,6 +86,15 @@ def getAvailableResources():
 
     return resources
 
+def getAvailableLanguages():
+    languages = set()
+    for l in lowLevel.getNativeAndForeignLanguages():
+        langCode = lowLevel.getLocaleNameFromTLW(l.decode("utf-8"))
+        if langCode is None:
+            continue
+        languages.add(langCode)
+    return languages
+
 class BgThread(threading.Thread):
 
     def __init__(self, bgQueue):
@@ -236,6 +245,7 @@ class SynthDriver(SynthDriver):
         self._veCallback = VE_CBOUTNOTIFY(VECallback(self._player, self._isSilence, self._onIndexReached))
 
         self._resources = getAvailableResources()
+        self.availableLanguages = getAvailableLanguages()
         self._languageDetector = languageDetection.LanguageDetector([l.id for l in self._resources])
         self._enableUnicodeLanguageSwitching = False
         self._waitfactor = 1
@@ -298,6 +308,7 @@ class SynthDriver(SynthDriver):
     def speak(self, speechSequence):
         currentInstance = defaultInstance = self.voiceInstance
         currentLanguage = defaultLanguage = self.language
+        defaultTlw = lowLevel.getTLWFromLocaleName(defaultLanguage)
         chunks = []
         hasText = False
         charMode = False
@@ -324,6 +335,7 @@ class SynthDriver(SynthDriver):
                 if command.lang is None:
                     currentInstance = defaultInstance
                     currentLanguage = defaultLanguage
+                    chunks.append(f"\x1b\\lang={defaultTlw}\\")
                     continue
                 currentLanguage = command.lang
                 newVoiceName = self.getVoiceNameForLanguage(currentLanguage)
@@ -336,6 +348,9 @@ class SynthDriver(SynthDriver):
                     self._bgQueue.put(TtsSetParamList(newInstance, (Param.PITCH, self.getParameter(self.voiceInstance, Param.PITCH))))
                     self._bgQueue.put(TtsSetParamList(newInstance, (Param.VOLUME, self.getParameter(self.voiceInstance, Param.VOLUME))))
                 if newInstance == currentInstance:
+                    tlw = lowLevel.getTLWFromLocaleName(currentLanguage)
+                    if tlw is not None:
+                        chunks.append(f"\x1b\\lang={tlw}\\")
                     continue
                 if hasText:
                     self._speak(currentInstance, chunks)
@@ -358,6 +373,10 @@ class SynthDriver(SynthDriver):
             else:
                 log.error(f"Unknown speech: {command}")
         if chunks:
+            if currentLanguage != defaultLanguage:
+                # Return to the default language of the voice.
+                # This ensures that the language is always reset for a new sequence.
+                chunks.append(f"\x1b\\lang={defaultTlw}\\")
             self._speak(currentInstance, chunks)
         self._bgQueue.put(DoneSpeaking(self._player, self._onIndexReached))
 

--- a/addon/synthDrivers/tiflotecniaVoices/lowLevel/__init__.py
+++ b/addon/synthDrivers/tiflotecniaVoices/lowLevel/__init__.py
@@ -5,7 +5,7 @@ import contextlib
 from ctypes import *
 
 from .structs import *
-from .languages import getLocaleNameFromTLW
+from .languages import getLocaleNameFromTLW, getTLWFromLocaleName
 
 from globalPlugins.tiflotecniaVoices.utils import *
 
@@ -270,6 +270,18 @@ def getSpeechDBList(languageName, voiceName):
     for i in range(nItems.value):
         voiceModels.append(speechDBInfos[i].szVoiceOperatingPoint.decode("utf-8"))
     return voiceModels
+
+def getNativeAndForeignLanguages():
+    languages = set()
+    for l in getLanguageList():
+        languages.add(l.szLanguageTLW)
+        for v in getVoiceList(l.szLanguage):
+            if not v.szForeignLanguages:
+                continue
+            for fl in v.szForeignLanguages.split(b','):
+                languages.add(fl.upper())
+    return languages
+
 
 def resourceLoad(contentType, content, instance):
     length = len(content)

--- a/addon/synthDrivers/tiflotecniaVoices/lowLevel/languages.py
+++ b/addon/synthDrivers/tiflotecniaVoices/lowLevel/languages.py
@@ -68,3 +68,7 @@ _vautoTLWToLocaleNames = {
 
 def getLocaleNameFromTLW(tlw):
 	return _vautoTLWToLocaleNames.get(tlw, None)
+
+
+def getTLWFromLocaleName(localeName):
+	return {v: k for k, v in _vautoTLWToLocaleNames.items()}.get(localeName, None)

--- a/addon/synthDrivers/tiflotecniaVoices/lowLevel/languages.py
+++ b/addon/synthDrivers/tiflotecniaVoices/lowLevel/languages.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 _vautoTLWToLocaleNames = {
 	"ARG": "ar",
 	"ARW": "ar",
@@ -70,5 +72,6 @@ def getLocaleNameFromTLW(tlw):
 	return _vautoTLWToLocaleNames.get(tlw, None)
 
 
+@lru_cache(maxsize=None)
 def getTLWFromLocaleName(localeName):
 	return {v: k for k, v in _vautoTLWToLocaleNames.items()}.get(localeName, None)


### PR DESCRIPTION
Vocalizer has several multi lingual voices, such as Claire ML, which supports not only Dutch, but also English and French. However, these language codes aren't being sent to the voice yet.

This pull request adds improved handling for language switching in the synthesizer driver. The main changes include tracking available languages on the driver, more reliably switching languages during speech output, and ensuring language context is reset at the end of each utterance.

**Language detection and switching improvements:**

* Added a new function `getAvailableLanguages()` to collect all native and foreign language codes supported by the voices, and exposed this as `availableLanguages` in the main driver class. This ensures that calling `languageIsSupported` also works. [[1]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R89-R97) [[2]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R248) [[3]](diffhunk://#diff-6f980f0d58c0ef9e86ebf3d739f279c3c4bd3d1776bdedc4fcc7c4a6c8904ae3R274-R285)
* Introduced `getTLWFromLocaleName()` in `lowLevel/languages.py` to map locale names back to TLW codes, supporting more reliable language switching. [[1]](diffhunk://#diff-b5f44646492710a36ec0dcb0d129de67851567d1597acbfc46b200d714f3088cR71-R74) [[2]](diffhunk://#diff-6f980f0d58c0ef9e86ebf3d739f279c3c4bd3d1776bdedc4fcc7c4a6c8904ae3L8-R8)
* In the `speak` method, now inserts language change commands (`\x1b\lang=...\`) whenever the language context changes or resets, and ensures the language is reset to the default at the end of each speech sequence. [[1]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R311) [[2]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R338) [[3]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R351-R353) [[4]](diffhunk://#diff-86ceeffbdfe784e3592bda8a705154d346e4c9fed5da45ef962a2665f3583890R376-R379)

Note that there is a known issue that voices do not advertise all the foreign languages they support. For example, Claire only reports ENG and ENU< while it definitely supports French as well.

To test, read the following with Claire:

<p lang="fr_fr">Je ne parle pas francais</p>
<p lang="nl_nl">Je ne parle pas francais</p>

The first sentence is pronounced in French, whereas the second exact same sentence is pronounced with Dutch rules.